### PR TITLE
Feature / Limit the number of scores in the feed

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.limit(25).all.order(played_at: :desc, id: :desc)
+      scores = Score.all.order(played_at: :desc, id: :desc).limit(25)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.includes(:user).limit(25).all.order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.includes(:user).limit(25).all.order(played_at: :desc, id: :desc)
+      scores = Score.limit(25).all.order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -9,10 +9,6 @@ describe Api::ScoresController, type: :request do
     @score1 = create(:score, user: @user1, total_score: 79, played_at: '2021-05-20')
     @score2 = create(:score, user: user2, total_score: 99, played_at: '2021-06-20')
     @score3 = create(:score, user: user2, total_score: 68, played_at: '2021-06-13')
-
-    25.times do
-      create(:score, user: @user1, total_score: 79, played_at: '2021-05-20')
-    end
   end
 
   describe 'GET feed' do
@@ -23,7 +19,7 @@ describe Api::ScoresController, type: :request do
       response_hash = JSON.parse(response.body)
       scores = response_hash['scores']
 
-      expect(scores.size).to eq 25
+      expect(scores.size).to eq 3
       expect(scores[0]['user_name']).to eq 'User2'
       expect(scores[0]['total_score']).to eq 99
       expect(scores[0]['played_at']).to eq '2021-06-20'
@@ -110,6 +106,10 @@ describe Api::ScoresController, type: :request do
   end
 
   it 'should allow only 25 scores to appear' do
+    25.times do
+      create(:score, user: @user1, total_score: 79, played_at: '2021-05-20')
+    end
+
     get api_feed_path
 
     expect(response).to have_http_status(:ok)

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -9,6 +9,10 @@ describe Api::ScoresController, type: :request do
     @score1 = create(:score, user: @user1, total_score: 79, played_at: '2021-05-20')
     @score2 = create(:score, user: user2, total_score: 99, played_at: '2021-06-20')
     @score3 = create(:score, user: user2, total_score: 68, played_at: '2021-06-13')
+
+    25.times do
+      create(:score, user: @user1, total_score: 79, played_at: '2021-05-20')
+    end
   end
 
   describe 'GET feed' do
@@ -19,7 +23,7 @@ describe Api::ScoresController, type: :request do
       response_hash = JSON.parse(response.body)
       scores = response_hash['scores']
 
-      expect(scores.size).to eq 3
+      expect(scores.size).to eq 25
       expect(scores[0]['user_name']).to eq 'User2'
       expect(scores[0]['total_score']).to eq 99
       expect(scores[0]['played_at']).to eq '2021-06-20'
@@ -103,5 +107,15 @@ describe Api::ScoresController, type: :request do
       expect(response).not_to have_http_status(:ok)
       expect(Score.count).to eq score_count
     end
+  end
+
+  it 'should allow only 25 scores to appear' do
+    get api_feed_path
+
+    expect(response).to have_http_status(:ok)
+    response_hash = JSON.parse(response.body)
+    scores = response_hash['scores']
+
+    expect(scores.size).to eq 25
   end
 end


### PR DESCRIPTION
Fixes: https://github.com/AACraiu/golfr_backend/issues/21

**Changes**

I added a method that limits the feed to the first 25 scores and a test for this method.

**Before**

<img width="1248" alt="Screenshot 2024-09-12 at 12 12 06" src="https://github.com/user-attachments/assets/61d34f0e-f03e-4d32-9efe-0567ce341992">


**After**

<img width="1248" alt="Screenshot 2024-09-12 at 12 11 40" src="https://github.com/user-attachments/assets/79bc67f0-dff7-439f-a105-1342eea64071">

